### PR TITLE
Standardization for carenet_health ads script

### DIFF
--- a/Clients/Carenet/Normalization Script/Ads/carenet_health_ads_performance.sql
+++ b/Clients/Carenet/Normalization Script/Ads/carenet_health_ads_performance.sql
@@ -1,4 +1,49 @@
-CREATE OR REPLACE TABLE `x-marketing.carenet_health.linkedin_ads_performance` AS
+-- CREATE OR REPLACE TABLE `x-marketing.carenet_health.linkedin_ads_performance` AS
+TRUNCATE TABLE `x-marketing.carenet_health.linkedin_ads_performance`;
+INSERT INTO  `x-marketing.carenet_health.linkedin_ads_performance` (
+  start_year,
+  start_month,
+  start_day,
+  end_month,
+  end_year,
+  end_day,
+  last_start_day,
+  start_week,
+  start_quater,
+  start_month_num,
+  weekday,
+  start_month_name,
+  start_week_num,
+  _date,
+  _estdate,
+  _quater_startdate,
+  creative_id,
+  _startDate,
+  _endDate,
+  _leads,
+  _reach,
+  _spent,
+  _impressions,
+  _clicks,
+  _conversions,
+  _landing_pages_clicks,
+  _video_views,
+  _lead_form_opens,
+  _video_play,
+  _video_views_25percent,
+  _video_views_50percent,
+  _video_views_75percent,
+  _video_completions,
+  account_id,
+  campaignID,
+  _campaignNames,
+  groupID,
+  _groupName,
+  dailyBudget,
+  cost_type,
+  status,
+  dailyBudget_per_ad
+) 
 WITH LI_ads AS (
  SELECT
     date_range.start.year AS start_year, 
@@ -69,27 +114,27 @@ campaign_group AS (
     FROM `x-marketing.carenet_health_linkedinzation_airtable_ads_linkedin` 
 ), */
 _all AS (
-SELECT
---airtable_ads.*EXCEPT(_adid), 
-  LI_ads.*,
-  campaigns.account_id,
-  campaigns.campaignID,
-  campaigns._campaignNames,
-  campaign_group.groupID,
-  campaign_group._groupName,
-  campaigns.dailyBudget,
-  campaigns.cost_type,
-  campaign_group.status
-FROM LI_ads
-RIGHT JOIN ads_title
-  ON CAST(LI_ads.creative_id AS STRING) = ads_title.cID
-LEFT JOIN campaigns
-  ON ads_title.campaign_id = campaigns.campaignID
-LEFT JOIN campaign_group
-  ON campaigns.campaign_group_id = campaign_group.groupID
-/* LEFT JOIN airtable_ads 
-ON 
-CAST(LI_ads.creative_id AS STRING) = CAST(airtable_ads._adid AS STRING) */
+  SELECT
+  --airtable_ads.*EXCEPT(_adid), 
+    LI_ads.*,
+    campaigns.account_id,
+    campaigns.campaignID,
+    campaigns._campaignNames,
+    campaign_group.groupID,
+    campaign_group._groupName,
+    campaigns.dailyBudget,
+    campaigns.cost_type,
+    campaign_group.status
+  FROM LI_ads
+  RIGHT JOIN ads_title
+    ON CAST(LI_ads.creative_id AS STRING) = ads_title.cID
+  LEFT JOIN campaigns
+    ON ads_title.campaign_id = campaigns.campaignID
+  LEFT JOIN campaign_group
+    ON campaigns.campaign_group_id = campaign_group.groupID
+  /* LEFT JOIN airtable_ads 
+  ON 
+  CAST(LI_ads.creative_id AS STRING) = CAST(airtable_ads._adid AS STRING) */
 ),
 daily_budget_per_ad_per_campaign AS (
   SELECT 

--- a/Clients/Carenet/Normalization Script/Ads/carenet_health_ads_performance.sql
+++ b/Clients/Carenet/Normalization Script/Ads/carenet_health_ads_performance.sql
@@ -1,0 +1,104 @@
+CREATE OR REPLACE TABLE `x-marketing.carenet_health.linkedin_ads_performance` AS
+WITH LI_ads AS (
+ SELECT
+    date_range.start.year AS start_year, 
+    date_range.start.month AS start_month, 
+    date_range.start.day AS start_day,
+    date_range.end.month AS end_month,
+    date_range.end.year AS end_year, 
+    date_range.end.day AS end_day,
+    LAST_DAY( CAST(start_at AS DATE) ,WEEK(MONDAY)) AS last_start_day,
+    TIMESTAMP_TRUNC(start_at, WEEK(MONDAY), 'UTC') AS start_week,
+    TIMESTAMP_TRUNC(start_at, QUARTER, 'UTC') AS start_quater,
+    TIMESTAMP_TRUNC(start_at, MONTH, 'UTC') AS start_month_num,
+    FORMAT_DATETIME('%A', start_at) AS weekday,
+    FORMAT_DATE('%B', start_at) AS start_month_name,
+    EXTRACT(WEEK FROM start_at) AS start_week_num,
+    EXTRACT(DATE FROM start_at) AS _date,
+    DATETIME (start_at, "America/New_York") AS _estdate,
+    CONCAT('Q',EXTRACT(QUARTER FROM start_at),'-',EXTRACT(YEAR FROM start_at) ) AS _quater_startdate,
+    creative_id,
+    start_at AS _startDate,
+    end_at AS _endDate,
+    one_click_leads AS _leads,
+    card_impressions AS _reach,
+    cost_in_usd AS _spent,
+    impressions AS _impressions,
+    clicks AS _clicks,
+    external_website_conversions AS _conversions,
+    landing_page_clicks AS _landing_pages_clicks,
+    video_views AS _video_views,
+    one_click_lead_form_opens AS _lead_form_opens,
+    video_starts AS _video_play,
+    video_first_quartile_completions AS _video_views_25percent,
+    video_midpoint_completions AS _video_views_50percent,
+    video_third_quartile_completions AS _video_views_75percent,
+    video_completions AS _video_completions
+  FROM `carenet_health_linkedin.ad_analytics_by_creative` 
+  ORDER BY start_at DESC
+),
+ads_title AS (
+  SELECT
+    SPLIT(SUBSTR(id, STRPOS(id, 'sponsoredCreative:')+18))[ORDINAL(1)] AS cID,
+    campaign_id
+  FROM `carenet_health_linkedin.creatives`
+),
+campaigns AS (
+  SELECT
+    id AS campaignID,
+    name AS _campaignNames,
+    status, --not used in main query// use status from campaign group
+    cost_type,
+    daily_budget.amount AS dailyBudget,
+    campaign_group_id,
+    account AS _account_name,
+    account_id
+  FROM `carenet_health_linkedin.campaigns`
+),
+campaign_group AS (
+  SELECT
+    id AS groupID,
+    name AS _groupName,
+    status
+  FROM `carenet_health_linkedin.campaign_groups`
+),
+/* airtable_ads AS (
+    SELECT 
+    * 
+    EXCEPT(_sdc_table_version,_sdc_received_at,_sdc_sequence,_sdc_batched_at) 
+    FROM `x-marketing.carenet_health_linkedinzation_airtable_ads_linkedin` 
+), */
+_all AS (
+SELECT
+--airtable_ads.*EXCEPT(_adid), 
+  LI_ads.*,
+  campaigns.account_id,
+  campaigns.campaignID,
+  campaigns._campaignNames,
+  campaign_group.groupID,
+  campaign_group._groupName,
+  campaigns.dailyBudget,
+  campaigns.cost_type,
+  campaign_group.status
+FROM LI_ads
+RIGHT JOIN ads_title
+  ON CAST(LI_ads.creative_id AS STRING) = ads_title.cID
+LEFT JOIN campaigns
+  ON ads_title.campaign_id = campaigns.campaignID
+LEFT JOIN campaign_group
+  ON campaigns.campaign_group_id = campaign_group.groupID
+/* LEFT JOIN airtable_ads 
+ON 
+CAST(LI_ads.creative_id AS STRING) = CAST(airtable_ads._adid AS STRING) */
+),
+daily_budget_per_ad_per_campaign AS (
+  SELECT 
+    *,
+    CASE 
+      WHEN COUNT(creative_id) OVER (PARTITION BY _startDate, _campaignNames ) > 0 
+      THEN dailyBudget / COUNT(creative_id) OVER (PARTITION BY _startDate, _campaignNames )
+      ELSE 0 
+    END AS dailyBudget_per_ad
+  FROM _all
+) 
+SELECT * FROM daily_budget_per_ad_per_campaign;

--- a/Clients/Carenet/Normalization Script/Ads/carenet_health_all_ads_perf.sql
+++ b/Clients/Carenet/Normalization Script/Ads/carenet_health_all_ads_perf.sql
@@ -1,4 +1,7 @@
-CREATE OR REPLACE TABLE `x-marketing.carenet_health.all_ads_performance` AS 
+-- CREATE OR REPLACE TABLE `x-marketing.carenet_health.all_ads_performance` AS 
+TRUNCATE TABLE `x-marketing.carenet_health.all_ads_performance`;
+INSERT INTO  `x-marketing.carenet_health.all_ads_performance` (
+)
 --+/ _google_sem \+--
 WITH carenet_health_ads_google AS (
   SELECT 

--- a/Clients/Carenet/Normalization Script/Ads/carenet_health_all_ads_perf.sql
+++ b/Clients/Carenet/Normalization Script/Ads/carenet_health_all_ads_perf.sql
@@ -69,12 +69,9 @@ carenet_health_campaign_google AS (
     ON campaign.id = activity.campaign_id
 ),
 _google_sem AS (
-  SELECT DISTINCT *
-  FROM (
-    SELECT * FROM carenet_health_ads_google
-    UNION ALL
-    SELECT * FROM carenet_health_campaign_google
-  )
+  SELECT * FROM carenet_health_ads_google
+  UNION ALL
+  SELECT * FROM carenet_health_campaign_google
 ),
 --+/ _6sense \+--
 carenet_ads_6sense AS (
@@ -90,17 +87,13 @@ carenet_ads_6sense AS (
     -- _advariation AS _ad_name,
     '' AS _ad_name,
     CASE 
-      WHEN _6sense._startdate = '-' 
-      THEN NULL 
-      WHEN _6sense._startdate = 'No End Date' 
-      THEN NULL 
+      WHEN _6sense._startdate = '-' THEN NULL 
+      WHEN _6sense._startdate = 'No End Date' THEN NULL 
       ELSE CAST(PARSE_DATE('%m/%e/%Y', _6sense._startdate) AS TIMESTAMP) 
     END,
     CASE 
-      WHEN _6sense._enddate = '-' 
-      THEN NULL 
-      WHEN _6sense._enddate = 'No End Date' 
-      THEN NULL 
+      WHEN _6sense._enddate = '-' THEN NULL 
+      WHEN _6sense._enddate = 'No End Date' THEN NULL 
       ELSE CAST(PARSE_DATE('%m/%e/%Y', _6sense._enddate) AS TIMESTAMP) 
     END,
     '6Sense' AS _platform, 
@@ -135,17 +128,13 @@ carenet_campaign_6sense AS (
     _campaignname AS _campaign_name, 
     '' AS _ad_name,
     CASE 
-      WHEN _6sense._startdate = '-' 
-      THEN NULL 
-      WHEN _6sense._startdate = 'No End Date' 
-      THEN NULL 
+      WHEN _6sense._startdate = '-' THEN NULL 
+      WHEN _6sense._startdate = 'No End Date' THEN NULL 
       ELSE CAST(PARSE_DATE('%d-%b-%y', _6sense._startdate) AS TIMESTAMP) 
     END,
     CASE 
-      WHEN _6sense._enddate = '-' 
-      THEN NULL 
-      WHEN _6sense._enddate = 'No End Date' 
-      THEN NULL 
+      WHEN _6sense._enddate = '-' THEN NULL 
+      WHEN _6sense._enddate = 'No End Date' THEN NULL 
       ELSE CAST(PARSE_DATE('%d-%b-%y', _6sense._enddate) AS TIMESTAMP) 
     END,
     '6Sense' AS _platform, 
@@ -172,12 +161,9 @@ carenet_campaign_6sense AS (
   ) = 1
 ),
 _6sense AS (
-  SELECT *
-  FROM (
-    SELECT * FROM carenet_ads_6sense
-    UNION ALL
-    SELECT * FROM carenet_campaign_6sense
-  )
+  SELECT * FROM carenet_ads_6sense
+  UNION ALL
+  SELECT * FROM carenet_campaign_6sense
 ),
 --+/ _6sense \+--
 --+/ _linkedin \+--
@@ -299,12 +285,9 @@ carenet_health_campaign_linkedin AS (
   ) = 1
 ),
 _linkedin AS (
-  SELECT * 
-  FROM (
-    SELECT * FROM carenet_health_ads_linkedin
-    -- UNION ALL
-    -- SELECT * FROM carenet_health_campaign_linkedin
-  )
+  SELECT * FROM carenet_health_ads_linkedin
+  -- UNION ALL
+  -- SELECT * FROM carenet_health_campaign_linkedin
 ),
 --+/ _linkedin \+--
 airtable_info AS (
@@ -312,6 +295,13 @@ airtable_info AS (
       *
     -- FROM `x-marketing.carenet_health_mysql.carenet_optimization_airtable_ads_linkedin`
     FROM `x-marketing.carenet_health_mysql.carenet_db_campaign_ad_id`
+), 
+_all AS (
+  SELECT * FROM _linkedin
+  -- UNION ALL 
+  -- SELECT * FROM _google_sem 
+  UNION ALL 
+  SELECT * FROM _6sense
 )
 SELECT 
   _all.*, 
@@ -323,11 +313,6 @@ SELECT
     ELSE CONCAT(CAST(_start_date AS DATE),' ','-',' ','No End Date') 
   END AS _campaign_date_range,
   airtable_info.* EXCEPT(_campaignid,_campaignname)
-FROM (
-  SELECT * FROM _linkedin
-  -- SELECT * FROM _google_sem 
-  UNION ALL 
-  SELECT * FROM _6sense
-) _all
+FROM _all
 LEFT JOIN airtable_info 
   ON CAST(_all.creative_id AS STRING) = CAST(airtable_info._adid AS STRING)

--- a/Clients/Carenet/Normalization Script/Ads/carenet_health_all_ads_perf.sql
+++ b/Clients/Carenet/Normalization Script/Ads/carenet_health_all_ads_perf.sql
@@ -1,7 +1,6 @@
 -- CREATE OR REPLACE TABLE `x-marketing.carenet_health.all_ads_performance` AS 
 TRUNCATE TABLE `x-marketing.carenet_health.all_ads_performance`;
-INSERT INTO  `x-marketing.carenet_health.all_ads_performance` (
-)
+INSERT INTO  `x-marketing.carenet_health.all_ads_performance` 
 --+/ _google_sem \+--
 WITH carenet_health_ads_google AS (
   SELECT 

--- a/Clients/Carenet/Normalization Script/Ads/carenet_health_all_ads_perf.sql
+++ b/Clients/Carenet/Normalization Script/Ads/carenet_health_all_ads_perf.sql
@@ -1,0 +1,350 @@
+CREATE OR REPLACE TABLE `x-marketing.carenet_health.all_ads_performance` AS 
+--// google_sem \\ -- 
+WITH carenet_health_ads_google AS (
+  SELECT 
+    activity.day AS _timestamp, 
+    activity.campaign_id AS _campaign_id, 
+    activity.ad_group_id AS _ad_group_id, 
+    ad_id AS _ad_id, 
+    ad_group_name AS _ad_group_name, 
+    activity.campaign_name AS _campaign_name,
+    ads.name AS _ad_name,
+    campaign.start_date AS _start_date,
+    campaign.end_date AS _end_date,
+    'Google SEM' AS _platform, 
+    'Carenet Health' AS _client,
+    'Ads' AS _type,
+    CASE 
+      WHEN activity.campaign_name LIKE '%Website Traffic%' 
+      THEN 'Website_Traffic'
+      WHEN activity.campaign_name LIKE 'Search || NB || Pentesting' 
+      THEN 'Lead_Generation' 
+      ELSE 'Lead_Generation' 
+    END AS _campaign_objective,
+    '' AS _landing_page,
+    '' AS _screenshot,
+    INITCAP(ads.type,'_') AS _ads_type,
+    activity.cost AS _spent, 
+    activity.impressions AS _impressions, 
+    activity.clicks AS _clicks, 
+    activity.conversions AS _conversions, 
+    NULL AS _leads,
+    NULL AS _landingpageclick
+  FROM `x-marketing.carenet_health.google_search_adsvariation_performance` activity
+  LEFT JOIN `x-marketing.carenet_google_ads.ads` ads 
+    ON ads.id = activity.ad_id
+  JOIN `x-marketing.carenet_google_ads.campaigns` campaign 
+    ON campaign.id = activity.campaign_id
+),
+carenet_health_campaign_google AS (
+  SELECT 
+    activity.day AS _timestamp, 
+    activity.campaign_id AS _campaign_id, 
+    NULL AS _ad_group_id, 
+    NULL AS _ad_id, 
+    '' AS _ad_group_name, 
+    activity.campaign_name AS _campaign_name,
+    '' AS _ad_name,
+    campaign.start_date AS _start_date,
+    campaign.end_date AS _end_date,
+    'Google SEM' AS _platform, 
+    'PlexTrac' AS _client,
+    'Campaign' AS _type,
+    CASE 
+      WHEN activity.campaign_name LIKE '%Website Traffic%' 
+      THEN 'Website_Traffic'
+      WHEN activity.campaign_name LIKE 'Search || NB || Pentesting' 
+      THEN 'Lead_Generation' 
+      ELSE 'Lead_Generation' 
+    END AS _campaign_objective,
+    '' AS _landing_page,
+    '' AS _screenshot,
+    '' AS _ads_type,
+    activity.cost AS _spent, 
+    activity.impressions AS _impressions, 
+    activity.clicks AS _clicks, 
+    activity.conversions AS _conversions, 
+    NULL AS _leads,
+    NULL AS _landingpageclick
+  FROM `x-marketing.carenet_health.google_search_campaign_performance` activity
+  JOIN `x-marketing.carenet_google_ads.campaigns` campaign 
+    ON campaign.id = activity.campaign_id
+), 
+_google_sem AS (
+  SELECT DISTINCT *
+  FROM (
+    SELECT * FROM carenet_health_ads_google
+    UNION ALL
+    SELECT * FROM carenet_health_campaign_google
+  )
+),
+--// google_sem \\ -- 
+--// 6sense \\ -- 
+carenet_ads_6sense AS (
+  SELECT 
+    CAST(PARSE_DATE('%m/%e/%Y', _6sense._date) AS TIMESTAMP) AS _timestamp, 
+    CAST(_6sense._campaignid AS INT64) AS _campaign_id, 
+    -- _adgroupid AS _ad_group_id, 
+    CAST(NULL AS INT64) AS _ad_group_id,
+    CAST(_6sense._6senseid AS INT64) AS _ad_id, 
+    -- _adgroup AS _ad_group_name,
+    _6sense._name AS _ad_group_name, 
+    _campaignname AS _campaign_name, 
+    -- _advariation AS _ad_name,
+    '' AS _ad_name,
+    CASE 
+      WHEN _6sense._startdate = '-' 
+      THEN NULL 
+      WHEN _6sense._startdate = 'No End Date' 
+      THEN NULL 
+      ELSE CAST(PARSE_DATE('%m/%e/%Y', _6sense._startdate) AS TIMESTAMP) 
+    END,
+    CASE 
+      WHEN _6sense._enddate = '-' 
+      THEN NULL 
+      WHEN _6sense._enddate = 'No End Date' 
+      THEN NULL 
+      ELSE CAST(PARSE_DATE('%m/%e/%Y', _6sense._enddate) AS TIMESTAMP) 
+    END,
+    '6Sense' AS _platform, 
+    'Carenet Health' AS _client,
+    'Ads' AS _type,
+    'Brand_Awareness' AS _campaign_objective,
+  --   '' AS _landing_page,
+    -- _adscreenshot AS _screenshot,
+  --   '' AS _screenshot,
+  --   '' AS _ads_type,
+    CAST(REPLACE(REPLACE(_6sense._spend, '$', ''), ',', '') AS FLOAT64) AS _spent, 
+    CAST(REPLACE(_6sense._impressions, ',', '') AS INTEGER) AS _impressions, 
+    CAST(_6sense._clicks AS INTEGER) AS _clicks, 
+    NULL AS _conversions,
+    NULL AS _leads, 
+    NULL AS _landingpageclick,
+    CAST(NULL AS STRING) AS _status
+  FROM `x-marketing.carenet_health_mysql.carenet_db_daily_campaign_performance__refurbished` _6sense
+  WHERE _datatype = 'Ad'
+),
+carenet_campaign_6sense AS (
+  SELECT 
+    CAST(PARSE_DATE('%m/%e/%Y', _6sense._date) AS TIMESTAMP) AS _timestamp, 
+    -- CAST(_campaignid AS INT64) AS _campaign_id
+    CAST(_6sense._6senseid AS INT64) AS _campaign_id, 
+    -- _adgroupid AS _ad_group_id, 
+    CAST(NULL AS INT64) AS _ad_group_id, 
+    CAST(NULL AS INT64) AS _ad_id, 
+    -- _adgroup AS _ad_group_name,
+    _6sense._name AS _ad_group_name, 
+    _campaignname AS _campaign_name, 
+    '' AS _ad_name,
+    CASE 
+      WHEN _6sense._startdate = '-' 
+      THEN NULL 
+      WHEN _6sense._startdate = 'No End Date' 
+      THEN NULL 
+      ELSE CAST(PARSE_DATE('%d-%b-%y', _6sense._startdate) AS TIMESTAMP) 
+    END,
+    CASE 
+      WHEN _6sense._enddate = '-' 
+      THEN NULL 
+      WHEN _6sense._enddate = 'No End Date' 
+      THEN NULL 
+      ELSE CAST(PARSE_DATE('%d-%b-%y', _6sense._enddate) AS TIMESTAMP) 
+    END,
+    '6Sense' AS _platform, 
+    'Carenet Health' AS _client,
+    'Campaign' AS _type,
+    'Brand_Awareness' AS _campaign_objective,
+  --   '' AS _landing_page,
+    -- _adscreenshot AS _screenshot,
+  --   '' AS _screenshot,
+  --   '' AS _ads_type,
+    CAST(REPLACE(REPLACE(_6sense._spend, '$', ''), ',', '') AS FLOAT64) AS _spent, 
+    CAST(REPLACE(_6sense._impressions, ',', '') AS INTEGER) AS _impressions, 
+    CAST(_6sense._clicks AS INTEGER) AS _clicks, 
+    NULL AS _conversions,
+    NULL AS _leads, 
+    NULL AS _landingpageclick,
+    CAST(NULL AS STRING) AS _status
+  FROM `x-marketing.carenet_health_mysql.carenet_db_daily_campaign_performance__refurbished` _6sense
+  WHERE _datatype = 'Campaign'
+  QUALIFY ROW_NUMBER() OVER(
+    PARTITION BY _6sense._6senseid, _6sense._date 
+    ORDER BY CAST(PARSE_DATE('%m/%e/%Y', _6sense._date) AS TIMESTAMP) DESC
+  ) = 1
+)
+_6sense AS (
+  SELECT *
+  FROM (
+    SELECT * FROM carenet_ads_6sense
+    UNION ALL
+    SELECT * FROM carenet_campaign_6sense
+  )
+),
+--// 6sense \\ -- 
+--// LinkedIn \\ -- 
+LI_ads (
+  SELECT 
+    start_at AS _timestamp,
+    creative_id,
+    cost_in_usd AS _spent,
+    impressions AS _impressions,
+    clicks AS _clicks,
+    external_website_conversions AS _conversions,
+    one_click_leads AS _leads,
+    landing_page_clicks AS _landingpageclicks
+  FROM `x-marketing.carenet_health_linkedin.ad_analytics_by_creative`
+),
+ads_title AS (
+  SELECT 
+    SPLIT(SUBSTR(id, STRPOS(id, 'sponsoredCreative:')+18))[ORDINAL(1)] AS cID,
+    campaign_id
+  FROM `x-marketing.carenet_health_linkedin.creatives`
+),
+campaigns AS (
+  SELECT 
+    id AS _campaignID,
+    name AS _campaignname,
+    campaign_group_id,
+    run_schedule.start AS _start_date,
+    run_schedule.end AS _end_date,
+    INITCAP(objective_type,'_') AS _campaign_objective
+  FROM `x-marketing.carenet_health_linkedin.campaigns`
+),
+campaign_group AS (
+  SELECT
+    id AS groupID,
+    name AS _groupName,
+    status AS _status
+  FROM `carenet_health_linkedin.campaign_groups`
+),
+carenet_health_ads_linkedin (
+  SELECT 
+    LI_ads._timestamp,
+    campaigns._campaignID,
+    campaign_group.groupID,
+    LI_ads.creative_id,
+    campaign_group._groupName,
+    campaigns._campaignname,
+    -- airtable_info._creativename,
+    '' AS _creativename,
+    campaigns._start_date,
+    campaigns._end_date,
+    'LinkedIn' AS _platform,
+    'Carenet Health' AS _client,
+    'Ads' AS _type,
+    _campaign_objective,
+    -- '' AS _landing_page,
+    -- '' AS _screenshot,
+    -- '' AS _ads_type,
+    _spent,
+    _impressions,
+    _clicks,
+    _conversions,
+    _leads,
+    _landingpageclicks,
+    campaign_group._status
+  FROM LI_ads
+  RIGHT JOIN ads_title 
+    ON CAST( LI_ads.creative_id AS STRING) = ads_title.cID
+  LEFT JOIN campaigns 
+    ON ads_title.campaign_id = campaigns._campaignID
+  JOIN campaign_group 
+    ON campaigns.campaign_group_id = campaign_group.groupID
+  WHERE _timestamp IS NOT NULL
+),
+LI_campaign AS (
+  SELECT 
+    start_at AS _timestamp,
+    campaign_id,
+    cost_in_usd AS _spent,
+    impressions AS _impressions,
+    clicks AS _clicks,
+    external_website_conversions AS _conversions,
+    one_click_leads AS _leads,
+    landing_page_clicks AS _landingpageclicks
+  FROM `x-marketing.carenet_health_linkedin.ad_analytics_by_campaign`
+),
+campaigns AS (
+  SELECT 
+    id AS _campaignID,
+    name AS _campaignname,
+    campaign_group_id,
+    run_schedule.start AS _start_date,
+    run_schedule.end AS _end_date,
+    INITCAP(objective_type,'_') AS _campaign_objective
+  FROM `x-marketing.carenet_health_linkedin.campaigns`
+),
+campaign_group AS (
+  SELECT
+    id AS groupID,
+    name AS _groupName,
+    status AS _status
+  FROM `carenet_health_linkedin.campaign_groups`
+)
+carenet_health_campaign_linkedin AS (
+  SELECT 
+    LI_campaign._timestamp,
+    campaigns._campaignID,
+    campaign_group.groupID,
+    NULL AS creative_id,
+    campaign_group._groupName,
+    campaigns._campaignname,
+    campaigns._start_date,
+    campaigns._end_date,
+    'LinkedIn' AS _platform,
+    'Carenet Health' AS _client,
+    'Campaign' AS _type,
+    _campaign_objective,
+    '' AS _landing_page,
+    '' AS _screenshot,
+    '' AS _ads_type,
+    _spent,
+    _impressions,
+    _clicks,
+    _conversions,
+    _leads,
+    _landingpageclicks,
+    campaign_group._status
+  FROM LI_campaign
+  LEFT JOIN campaigns 
+    ON LI_campaign.campaign_id = campaigns._campaignID
+  JOIN campaign_group 
+    ON campaigns.campaign_group_id = campaign_group.groupID
+  WHERE _timestamp IS NOT NULL
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY LI_campaign._timestamp, campaigns._campaignID 
+    ORDER BY LI_campaign._timestamp DESC
+  ) = 1
+)
+_linkedin AS (
+  SELECT * 
+  FROM (
+    SELECT * FROM carenet_health_campaign_linkedin
+    -- UNION ALL
+    -- SELECT * FROM carenet_health_campaign
+  )
+),
+--// LinkedIn \\ --
+airtable_info AS (
+  SELECT 
+    *
+  FROM `x-marketing.carenet_health_mysql.carenet_db_campaign_ad_id`
+)
+SELECT 
+  _all.*, 
+  CASE 
+    WHEN _end_date IS NOT NULL 
+    THEN CONCAT(CAST(_start_date AS DATE),' ','-',' ',CAST(_end_date AS DATE)) 
+    WHEN _start_date IS NULL 
+    THEN 'Not Stated'
+    ELSE CONCAT(CAST(_start_date AS DATE),' ','-',' ','No End Date') 
+  END AS _campaign_date_range,
+  airtable_info.* EXCEPT(_campaignid,_campaignname)
+FROM (
+  SELECT * FROM _linkedin
+  -- SELECT * FROM _google_sem 
+  UNION ALL 
+  SELECT * FROM _6sense
+) _all
+LEFT JOIN airtable_info 
+  ON CAST(_all.creative_id AS STRING) = CAST(airtable_info._adid AS STRING)


### PR DESCRIPTION
Update :
1. Remove subqueries and nested CTE
2. Update format
3. Changes the flow for more optimize and remove redundancy

Left is new script Right is old script to compare no of rows:

1. x-marketing.carenet_health.linkedin_ads_performance
![image](https://github.com/user-attachments/assets/6cabd388-a48e-4c53-afe6-8e7575eadf86)
2. x-marketing.carenet_health.all_ads_performance
![image](https://github.com/user-attachments/assets/da7a1519-b41c-4573-97bc-bc0274587b7d)

