### PR TITLE
Standardization: logicsource content engagement

### DIFF
--- a/Clients/Logicsource/Normalization Script/Content_Engagement/logicsource_content_analytics_consolidation.sql
+++ b/Clients/Logicsource/Normalization Script/Content_Engagement/logicsource_content_analytics_consolidation.sql
@@ -1,0 +1,88 @@
+-- CREATE OR REPLACE TABLE `x-marketing.logicsource.db_consolidation_content_analytics` AS
+TRUNCATE TABLE `x-marketing.logicsource.db_consolidation_content_analytics`;
+INSERT INTO `x-marketing.logicsource.db_consolidation_content_analytics`
+(
+  _contentitem,
+  _contenttype,
+  _gatingstrategy,
+  _homeurl,
+  _summary,
+  _status,
+  _buyerstage,
+  _vertical,
+  _persona,
+  _engagement
+)
+WITH content_inventory AS (
+  SELECT
+    _contentitem,
+    _contenttype,
+    _gatingstrategy,
+    _homeurl,
+    _summary,
+    _status,
+    _buyerstage,
+    _vertical,
+    _persona,
+  FROM `x-marketing.logicsource_mysql.db_airtable_content_inventory` 
+),
+email AS (
+  SELECT
+    _homeurl,
+    CONCAT("Email ", INITCAP(_engagement)) AS _engagement
+  FROM `x-marketing.logicsource.db_email_content_analytics` 
+),
+ads AS (
+  SELECT
+    _homeurl,
+    'Ads' AS _engagement
+  FROM `x-marketing.logicsource.db_ads_content_analytics`
+),
+web AS (
+  SELECT
+    _homeurl,
+    'Web' AS _engagement
+  FROM `x-marketing.logicsource.db_web_content_analytics`
+)
+
+SELECT 
+  content_inventory.*,
+  CASE
+    WHEN _engagement != ''
+    THEN _engagement
+    ELSE CAST(NULL AS STRING)
+  END AS _engagement
+FROM content_inventory
+LEFT JOIN (
+  SELECT
+    *
+  FROM email
+  UNION ALL
+  SELECT
+    *
+  FROM ads
+  UNION ALL
+  SELECT
+    *
+  FROM web 
+) engagement
+ON engagement._homeurl = content_inventory._homeurl
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Clients/Logicsource/Normalization Script/Content_Engagement/logicsource_content_analytics_consolidation.sql
+++ b/Clients/Logicsource/Normalization Script/Content_Engagement/logicsource_content_analytics_consolidation.sql
@@ -1,7 +1,7 @@
 -- CREATE OR REPLACE TABLE `x-marketing.logicsource.db_consolidation_content_analytics` AS
 TRUNCATE TABLE `x-marketing.logicsource.db_consolidation_content_analytics`;
-INSERT INTO `x-marketing.logicsource.db_consolidation_content_analytics`
-(
+
+INSERT INTO `x-marketing.logicsource.db_consolidation_content_analytics` (
   _contentitem,
   _contenttype,
   _gatingstrategy,
@@ -24,13 +24,14 @@ WITH content_inventory AS (
     _buyerstage,
     _vertical,
     _persona,
-  FROM `x-marketing.logicsource_mysql.db_airtable_content_inventory` 
+  FROM `x-marketing.logicsource_mysql.db_airtable_content_inventory`
 ),
 email AS (
   SELECT
     _homeurl,
     CONCAT("Email ", INITCAP(_engagement)) AS _engagement
-  FROM `x-marketing.logicsource.db_email_content_analytics` 
+  FROM
+    `x-marketing.logicsource.db_email_content_analytics`
 ),
 ads AS (
   SELECT
@@ -43,17 +44,8 @@ web AS (
     _homeurl,
     'Web' AS _engagement
   FROM `x-marketing.logicsource.db_web_content_analytics`
-)
-
-SELECT 
-  content_inventory.*,
-  CASE
-    WHEN _engagement != ''
-    THEN _engagement
-    ELSE CAST(NULL AS STRING)
-  END AS _engagement
-FROM content_inventory
-LEFT JOIN (
+),
+engagement_merged AS (
   SELECT
     *
   FROM email
@@ -64,25 +56,11 @@ LEFT JOIN (
   UNION ALL
   SELECT
     *
-  FROM web 
-) engagement
-ON engagement._homeurl = content_inventory._homeurl
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  FROM web
+)
+SELECT
+  content_inventory.*,
+  IF(_engagement != '', _engagement, CAST(NULL AS STRING)) AS _engagement
+FROM content_inventory
+LEFT JOIN engagement_merged
+  ON engagement_merged._homeurl = content_inventory._homeurl;

--- a/Clients/Logicsource/Normalization Script/Content_Engagement/logicsource_content_engagements_log.sql
+++ b/Clients/Logicsource/Normalization Script/Content_Engagement/logicsource_content_engagements_log.sql
@@ -1,17 +1,60 @@
 --------------------------------------------------------------------------------------------------------------------------------------------
 ------------------------------------------------------------ Updated Content script ------------------------------------------------------------
 --------------------------------------------------------------------------------------------------------------------------------------------
-
 TRUNCATE TABLE `x-marketing.logicsource.db_content_engagements_log`;
+
 --CREATE OR REPLACE TABLE `x-marketing.logicsource.db_content_engagements_log` AS
-INSERT INTO `x-marketing.logicsource.db_content_engagements_log`
+INSERT INTO `x-marketing.logicsource.db_content_engagements_log` (
+  _type,
+  _wiseid,
+  _publishdate,
+  _url,
+  _status,
+  _requester,
+  _lastreviewed,
+  _airtableid,
+  _vertical,
+  _gating,
+  _requestdate,
+  _buyerstage,
+  _writer,
+  _persona,
+  _completedate,
+  _summary,
+  _startdate,
+  _created,
+  _title,
+  _intentkeyword,
+  _contentID,
+  _visitDate,
+  _pageviews,
+  _visitorID,
+  _domain
+)
+WITH content AS (
+  SELECT DISTINCT
+    *
+  FROM `x-marketing.logicsource_mysql.content_wise_mapping`
+  WHERE
+    _url != ''
+),
+web AS (
+  SELECT DISTINCT
+    _visitorid,
+    _domain,
+    _timestamp,
+    _fullurl,
+  FROM `x-marketing.logicsource.db_web_engagements_log`
+  ORDER BY
+    _timestamp DESC
+)
 SELECT DISTINCT
-  content.* EXCEPT(
-      _id,
-      _sdc_batched_at,
-      _sdc_received_at,
-      _sdc_sequence,
-      _sdc_table_version
+  content.* EXCEPT (
+    _id,
+    _sdc_batched_at,
+    _sdc_received_at,
+    _sdc_sequence,
+    _sdc_table_version
   ),
   content._id AS _contentID,
   -- PARSE_DATE('%e-%b-%y', content._publishdate) AS _publishedDate,
@@ -19,43 +62,31 @@ SELECT DISTINCT
   1 AS _pageviews,
   web._visitorid AS _visitorID,
   web._domain,
-FROM 
-  (
-    SELECT DISTINCT * 
-    FROM `x-marketing.logicsource_mysql.content_wise_mapping` 
-    WHERE _url !=''
-  ) AS content 
-LEFT JOIN 
-  (
-    SELECT 
-        DISTINCT 
-        _visitorid, 
-        _domain,
-        _timestamp,
-        _fullurl,
-    FROM 
-        `x-marketing.logicsource.db_web_engagements_log`
-    ORDER BY 
-        _timestamp DESC
-  ) AS web 
-  ON content._url = web._fullurl
-;
-
+FROM content
+LEFT JOIN web
+  ON content._url = web._fullurl;
 
 -- Extracting hot intent topics based on the content wise mapping
+TRUNCATE TABLE `x-marketing.logicsource.report_content_topic_metrics`;
 
-TRUNCATE TABLE `logicsource.report_content_topic_metrics`;
-INSERT INTO  `logicsource.report_content_topic_metrics` 
-SELECT
-  DISTINCT _domain, LOWER(keywords) AS _keywords, _visitDate, _contentID, _url, _pageviews
-FROM
-  `logicsource.db_content_engagements_log` content,
-  UNNEST(SPLIT(_intentkeyword, ', ')) AS keywords
-WHERE
-  _intentkeyword IS NOT NULL 
-  AND _intentkeyword !='' 
+INSERT INTO `x-marketing.logicsource.report_content_topic_metrics` (
+  _domain,
+  _keywords,
+  _visitDate,
+  _contentID,
+  _url,
+  _pageviews
+)
+SELECT DISTINCT
+  _domain,
+  LOWER(keywords) AS _keywords,
+  _visitDate,
+  _contentID,
+  _url,
+  _pageviews
+FROM `x-marketing.logicsource.db_content_engagements_log` content,
+  UNNEST (SPLIT(_intentkeyword, ', ')) AS keywords
+WHERE _intentkeyword IS NOT NULL
+  AND _intentkeyword != ''
   AND _visitdate IS NOT NULL
-ORDER BY
-  1;
-
-
+ORDER BY 1;

--- a/Clients/Logicsource/Normalization Script/Content_Engagement/logicsource_content_engagements_log.sql
+++ b/Clients/Logicsource/Normalization Script/Content_Engagement/logicsource_content_engagements_log.sql
@@ -1,0 +1,61 @@
+--------------------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------ Updated Content script ------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------------------------------------
+
+TRUNCATE TABLE `x-marketing.logicsource.db_content_engagements_log`;
+--CREATE OR REPLACE TABLE `x-marketing.logicsource.db_content_engagements_log` AS
+INSERT INTO `x-marketing.logicsource.db_content_engagements_log`
+SELECT DISTINCT
+  content.* EXCEPT(
+      _id,
+      _sdc_batched_at,
+      _sdc_received_at,
+      _sdc_sequence,
+      _sdc_table_version
+  ),
+  content._id AS _contentID,
+  -- PARSE_DATE('%e-%b-%y', content._publishdate) AS _publishedDate,
+  web._timestamp AS _visitDate,
+  1 AS _pageviews,
+  web._visitorid AS _visitorID,
+  web._domain,
+FROM 
+  (
+    SELECT DISTINCT * 
+    FROM `x-marketing.logicsource_mysql.content_wise_mapping` 
+    WHERE _url !=''
+  ) AS content 
+LEFT JOIN 
+  (
+    SELECT 
+        DISTINCT 
+        _visitorid, 
+        _domain,
+        _timestamp,
+        _fullurl,
+    FROM 
+        `x-marketing.logicsource.db_web_engagements_log`
+    ORDER BY 
+        _timestamp DESC
+  ) AS web 
+  ON content._url = web._fullurl
+;
+
+
+-- Extracting hot intent topics based on the content wise mapping
+
+TRUNCATE TABLE `logicsource.report_content_topic_metrics`;
+INSERT INTO  `logicsource.report_content_topic_metrics` 
+SELECT
+  DISTINCT _domain, LOWER(keywords) AS _keywords, _visitDate, _contentID, _url, _pageviews
+FROM
+  `logicsource.db_content_engagements_log` content,
+  UNNEST(SPLIT(_intentkeyword, ', ')) AS keywords
+WHERE
+  _intentkeyword IS NOT NULL 
+  AND _intentkeyword !='' 
+  AND _visitdate IS NOT NULL
+ORDER BY
+  1;
+
+


### PR DESCRIPTION
Changes made:
1. Removed subqueries
2. Updated overall formatting

Ive checked the row count and they all seem to match. db_content_engagements_log has 0 rows (expected)
![image](https://github.com/user-attachments/assets/bf22add9-565e-4e1c-b974-55a26339b3b6)

I'll update these into the scheduler once updated tqqqqq