### PR TITLE
Sandler airtable migration

### DIFF
--- a/Clients/Sandler/Normalization Script/Ads/sandler_ads_engagement_log.sql
+++ b/Clients/Sandler/Normalization Script/Ads/sandler_ads_engagement_log.sql
@@ -1,0 +1,291 @@
+CREATE OR REPLACE TABLE `x-marketing.sandler.ads_engagement_log` AS
+WITH airtable_ads AS (
+ 
+  WITH
+    airtable AS (
+      SELECT * EXCEPT (_rownum)
+      FROM (
+        SELECT * EXCEPT (
+          _sdc_batched_at, 
+          _sdc_received_at,
+          _sdc_sequence, 
+          _sdc_table_version
+        ),
+        "Awareness" AS _stage,
+        ROW_NUMBER() OVER (PARTITION BY _adid ORDER BY _sdc_received_at DESC)
+        AS _rownum
+        FROM
+          `x-marketing.sandlernetwork_mysql.sandlernetwork_optimization_airtable_ads_linkedin`
+        WHERE _platform != ""
+      )
+      WHERE _rownum = 1
+    ),
+    ads_title AS(
+      SELECT
+        SPLIT(SUBSTR(creative.id, STRPOS(creative.id, 'sponsoredCreative:')+18))[ORDINAL(1)]  AS cID,
+        creative.campaign_id,
+        creative.account_id,
+        creative.intended_status,
+        video.name AS _advariation,
+        video.content_reference AS _content
+      FROM
+        `x-marketing.sandler_linkedin_ads.creatives` creative
+      LEFT JOIN
+        `x-marketing.sandler_linkedin_ads.video_ads` video
+      ON
+        creative.content.reference = video.content_reference
+    ),
+    campaigns AS (
+      SELECT
+        id AS campaignID,
+        name AS _campaignName,
+        status,
+        cost_type,
+        total_budget.amount AS total_budget,
+        campaign_group_id,
+        TIMESTAMP_DIFF(run_schedule.end, run_schedule.start, DAY) AS date_diffs,
+        type
+      FROM
+        `x-marketing.sandler_linkedin_ads.campaigns`
+    ),
+    campaign_group AS (
+      SELECT
+        id AS groupID,
+        name AS _groupName,
+        status
+      FROM `x-marketing.sandler_linkedin_ads.campaign_groups`
+    ),
+    --COMBINE ALL ATTRIBUTES FOR LINKEDIN--
+    linkedin AS (
+      SELECT
+        CAST(campaignID AS STRING) AS _campaign,
+        ads_title.cID AS _adid,
+        campaigns.campaign_group_id AS ad_group_id,
+        campaigns.status,
+        ads_title._advariation,
+        ads_title._content,
+        _screenshot AS _screenshot,
+        campaign_group._groupName AS _reportinggroup,
+        'LinkedIn' AS _source,
+        _platform  AS _medium,
+        "" AS _id,
+        campaigns.type AS _adtype,
+        'LinkedIn' AS _platform,
+        "" AS _asset,
+        _websiteurl AS _landingpageurl,
+        campaigns._campaignName AS _campaignname,
+        "Awareness" AS _stage
+      FROM ads_title
+      LEFT JOIN campaigns
+        ON ads_title.campaign_id = campaigns.campaignID 
+      LEFT JOIN campaign_group
+        ON campaigns.campaign_group_id = campaign_group.groupID
+      LEFT JOIN airtable
+        ON ads_title.cID = CAST(airtable._adid AS STRING)
+    ),
+    --COMBINE ALL ATTRIBUTES FOR GOOGLE--
+    google AS (
+      SELECT
+        CAST(adgroup.campaign_id AS STRING) AS _campaign,
+        "" AS _adid,
+        adgroup.id AS ad_group_id,
+        campaign.status AS _status,
+        "" AS _advariation,
+        "" AS _content,
+        "" AS _screenshot,
+        adgroup.name AS _reportinggroup,
+        "" AS _source,
+        "" AS _medium,
+        "" AS _id,
+        "" AS _adtype,
+        "Google" AS _platform,
+        "" AS _asset,
+        "" AS _landingpageurl,
+        campaign.name AS _campaignname,
+        "Awareness" AS _stage   
+      FROM
+        `x-marketing.sandler_google_ads.ad_groups` adgroup
+      LEFT JOIN
+        `x-marketing.sandler_google_ads.campaigns` campaign
+      ON adgroup.campaign_id = campaign.id
+    ), _6sense AS (
+
+      SELECT 
+        CAST(other._campaignid AS STRING) AS _campaign,
+        _adid AS _adid,
+        0 AS ad_group_id,
+        "" AS _status,
+        _adname AS _advariation,
+        "" AS _content,
+        "" AS _screenshot,
+        "" AS _reportinggroup,
+        "" AS _source,
+        "" AS _medium,
+        "" AS _id,
+        "" AS _adtype,
+        "6sense" AS _platform,
+        "" AS _asset,
+        "" AS _landingpageurl,
+       _campaignname AS _campaignname,
+        "Awareness" AS _stage 
+      FROM `x-marketing.sandler_mysql.optimization_airtable_ads_6sense`  AS other 
+      --JOIN  `x-marketing.sandler_mysql.sandler_db_campaign_info`  AS campaign
+--ON other._campaignid = campaign._campaignid
+WHERE 
+      /* _sdc_deleted_at IS NULL 
+      AND */ LENGTH(_adid)>2 and _campaignid IS NOT NULL
+
+    )
+    SELECT *
+    FROM linkedin
+    UNION ALL
+    SELECT * FROM google
+    UNION ALL
+    SELECT * FROM _6sense
+),
+--METRICS COLUMNS--
+ads_metrics AS (
+  --METRICS COLUMNS FOR LINKEDIN--
+  WITH linkedin_ads AS (
+    SELECT
+      main.creative_id AS ad_id,
+      creative.campaign_id,
+      campaign_group.id AS ad_group_id,
+      main.start_at AS day,
+      CAST(main.cost_in_usd AS FLOAT64) AS spent,
+      main.impressions,
+      main.clicks,
+      "LinkedIn" AS _platform_type
+    FROM
+      `x-marketing.sandler_linkedin_ads.ad_analytics_by_creative` main
+    JOIN
+      `x-marketing.sandler_linkedin_ads.creatives` creative
+      ON CAST(main.creative_id AS STRING) = SPLIT(SUBSTR(creative.id, STRPOS(creative.id, 'sponsoredCreative:')+18))[ORDINAL(1)]
+    JOIN
+      `x-marketing.sandler_linkedin_ads.campaigns` campaign
+        ON creative.campaign_id = campaign.id
+    JOIN
+      `x-marketing.sandler_linkedin_ads.campaign_groups` campaign_group
+      ON campaign.campaign_group_id = campaign_group.id
+    ORDER BY
+      main.start_at DESC
+  ),
+    --METRICS COLUMNS FOR GOOGLE--
+  google_ads AS (
+    SELECT
+      NULL AS ad_id,
+      campaign.campaign_id,
+      ad_group_id AS ad_group_id,
+      campaign.date AS day,
+      campaign.cost_micros/1000000 AS spent,
+      campaign.impressions AS impressions, 
+      campaign.clicks,
+      "Google" AS _platform_type,
+    FROM
+      `x-marketing.sandler_google_ads.ad_group_performance_report` campaign
+  ) , _6sense AS (
+    SELECT
+    CAST(_adid AS INT64) AS ad_id,
+    CAST(campaignID AS INT64) AS _campaignid,
+    NULL AS ad_group_id, 
+    CAST(_date AS TIMESTAMP) AS _date,
+    SUM(spend) AS _spend, 
+   SUM(impressions) AS _impressions, 
+   SUM(clicks) AS _clicks, 
+    "6sense"
+FROM 
+    `x-marketing.sandler.db_6sense_ads_overview`
+    WHERE 
+    _date IS NOT NULL
+    GROUP BY 1,2,3,4
+  )
+SELECT *
+FROM (
+  SELECT * FROM linkedin_ads
+  UNION ALL
+  SELECT * FROM google_ads
+  UNION ALL
+  SELECT * FROM _6sense
+)
+),
+--COMBINE MAIN ADS WITH METRICS--
+all_ads AS (
+  WITH linkedin_ads AS (
+    SELECT * EXCEPT (_adid, _campaign, ad_group_id)
+    FROM airtable_ads
+    JOIN ads_metrics
+      ON CAST(ads_metrics.ad_id AS STRING) = airtable_ads._adid
+    WHERE _platform = "LinkedIn"
+  ),
+  google_ads AS (
+  SELECT * EXCEPT(_adid,_campaign,ad_group_id)
+    FROM airtable_ads
+    JOIN ads_metrics
+      ON CAST(ads_metrics.campaign_id AS STRING) = airtable_ads._campaign
+      AND airtable_ads.ad_group_id = ads_metrics.ad_group_id
+    WHERE _platform = "Google"
+  ),
+  _6sense AS (
+  SELECT * EXCEPT(_adid,_campaign,ad_group_id)
+    FROM airtable_ads
+    JOIN ads_metrics
+      ON CAST(ads_metrics.ad_id AS STRING) = airtable_ads._adid
+    WHERE _platform =  "6sense"
+  )
+  SELECT *
+    FROM (
+      SELECT * FROM linkedin_ads
+      UNION ALL
+      SELECT * FROM google_ads
+      UNION ALL
+      SELECT * FROM _6sense
+    )
+),
+--ADDITIONAL ATRRIBUTES FROM WEB ENGAGEMENT--
+get_web_page_views AS (
+  SELECT
+    ad.day,
+    ad._landingpageurl,
+    ad.ad_count,
+    ad._source,
+    COUNT(DISTINCT web._visitorid) AS visitors,
+    SUM(web._totalsessionviews) AS pageviews
+    FROM (
+      SELECT DISTINCT
+          CAST(_timestamp AS DATE) AS _date,
+          _visitorid,
+          _fullurl AS _fullpage,
+          _totalsessionviews,
+          _utmsource
+      FROM `x-marketing.sandler.db_web_engagements_log`
+    ) web
+    JOIN (
+        SELECT DISTINCT
+            day,
+            _source,
+            _landingpageurl,
+            COUNT(DISTINCT ad_id) AS ad_count
+        FROM all_ads
+        GROUP BY 1, 2, 3
+        ORDER BY 4 DESC
+    ) ad 
+    ON ad._landingpageurl LIKE CONCAT('%', web._fullpage, '%')
+    AND EXTRACT(DATETIME FROM ad.day) = web._date
+    WHERE UPPER(ad._source) = UPPER(web._utmsource) 
+    AND web._utmsource IN('linkedin', 'LinkedIn', 'Google')
+    GROUP BY 1, 2, 3, 4
+)
+SELECT
+        main.*,
+        side.pageviews,
+        side.pageviews / side.ad_count AS reduced_pageviews,
+        side.visitors,
+        side.visitors / side.ad_count AS reduced_visitors
+    FROM all_ads AS main
+    LEFT JOIN get_web_page_views AS side 
+    ON main.day = side.day 
+    AND main._landingpageurl = side._landingpageurl
+    AND main._source = side._source
+
+
+


### PR DESCRIPTION
Changes made:
1. Update source to use google sheets instead of airtable. Refer [commit](https://github.com/2x-data-ops/dataops-client-services/commit/f4972b96c78e914f0132713d1e8673c66fd54600)

I have checked the row count and it only matches for sandler_ads_engagement_log but **not** sandler_dashboard_ads_optimization. Do refer the screenshot below

**sandler_ads_engagement_log**:
![image](https://github.com/user-attachments/assets/e9c3b686-b381-4e96-affb-5a889919e7a2)

**sandler_dashboard_ads_optimization**:
I think this is likely bcs of the source not being updated during the mysql port recovery and causing the data to not be updated. So the rows from the google sheets outnumber the old one in airtable
![image](https://github.com/user-attachments/assets/7e31e917-be58-4e18-94a2-5a67ad700729)

I'll update these scripts in the scheduler once approved. Thanks!
